### PR TITLE
Fix the crash when hitting return button

### DIFF
--- a/video-overlay-jni-example/app/src/main/java/com/projecttango/experiments/nativevideooverlay/VideoOverlayActivity.java
+++ b/video-overlay-jni-example/app/src/main/java/com/projecttango/experiments/nativevideooverlay/VideoOverlayActivity.java
@@ -89,7 +89,6 @@ public class VideoOverlayActivity extends Activity
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    TangoJNINative.freeGLContent();
   }
 
   private void EnableYUVTexture(boolean isEnabled) {


### PR DESCRIPTION
Removed `freeGLContent()` from the `onDestroy` method that was causing
double free of the drawable objects. It's already freed on the `onPause`
method.