### PR TITLE
On windows you must add ".cmd" when calling "ndk-build"

### DIFF
--- a/rgb-depth-sync-example/app/build.gradle
+++ b/rgb-depth-sync-example/app/build.gradle
@@ -35,7 +35,7 @@ tasks.withType(JavaCompile) {
 task ndkBuild(type: Exec) {
     Properties properties = new Properties()
     properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    def ndkbuild = properties.getProperty('ndk.dir', null) +"/ndk-build" + (Os.isFamily(Os.FAMILY_WINDOWS) ? ".cmd" : "")
+    def ndkbuild = properties.getProperty('ndk.dir', null)+"/ndk-build"+(Os.isFamily(Os.FAMILY_WINDOWS) ? ".cmd" : "")
     commandLine ndkbuild, '-C', file('src/main/jni').absolutePath
 }
 

--- a/rgb-depth-sync-example/app/build.gradle
+++ b/rgb-depth-sync-example/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+import org.apache.tools.ant.taskdefs.condition.Os
 
 android {
     compileSdkVersion 19
@@ -34,7 +35,7 @@ tasks.withType(JavaCompile) {
 task ndkBuild(type: Exec) {
     Properties properties = new Properties()
     properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    def ndkbuild = properties.getProperty('ndk.dir', null)+"/ndk-build"
+    def ndkbuild = properties.getProperty('ndk.dir', null) +"/ndk-build" + (Os.isFamily(Os.FAMILY_WINDOWS) ? ".cmd" : "")
     commandLine ndkbuild, '-C', file('src/main/jni').absolutePath
 }
 


### PR DESCRIPTION
See: http://stackoverflow.com/questions/27477158/android-studio-ndk-build-trouble-errorexecution-failed-for-task-appbuildnati