### PR TITLE
Build example projects for all available architectures

### DIFF
--- a/cpp_augmented_reality_example/app/src/main/jni/Application.mk
+++ b/cpp_augmented_reality_example/app/src/main/jni/Application.mk
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_basic_examples/hello_area_description/src/main/jni/Application.mk
+++ b/cpp_basic_examples/hello_area_description/src/main/jni/Application.mk
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_basic_examples/hello_depth_perception/src/main/jni/Application.mk
+++ b/cpp_basic_examples/hello_depth_perception/src/main/jni/Application.mk
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_basic_examples/hello_motion_tracking/src/main/jni/Application.mk
+++ b/cpp_basic_examples/hello_motion_tracking/src/main/jni/Application.mk
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_basic_examples/hello_video/src/main/jni/Application.mk
+++ b/cpp_basic_examples/hello_video/src/main/jni/Application.mk
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_motion_tracking_example/app/src/main/jni/Application.mk
+++ b/cpp_motion_tracking_example/app/src/main/jni/Application.mk
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_plane_fitting_example/app/src/main/jni/Application.mk
+++ b/cpp_plane_fitting_example/app/src/main/jni/Application.mk
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_point_cloud_example/app/src/main/jni/Application.mk
+++ b/cpp_point_cloud_example/app/src/main/jni/Application.mk
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_point_to_point_example/app/src/main/jni/Application.mk
+++ b/cpp_point_to_point_example/app/src/main/jni/Application.mk
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/cpp_rgb_depth_sync_example/app/src/main/jni/Application.mk
+++ b/cpp_rgb_depth_sync_example/app/src/main/jni/Application.mk
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86
 APP_STL := gnustl_static
 APP_PLATFORM := android-19

--- a/tango_client_api/Android.mk
+++ b/tango_client_api/Android.mk
@@ -12,10 +12,16 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := tango_client_api
 
 
-ifeq ($(TARGET_ARCH),x86)
-    LOCAL_EXPORT_LDLIBS := -L$(LOCAL_PATH)/lib/x86 -ltango_client_api
-else
-    LOCAL_EXPORT_LDLIBS := -L$(LOCAL_PATH)/lib/armeabi-v7a -ltango_client_api
+ifeq ($(TARGET_ARCH), x86)
+  LOCAL_EXPORT_LDLIBS := -L$(LOCAL_PATH)/lib/x86 -ltango_client_api
+endif
+
+ifeq ($(TARGET_ARCH), arm64)
+  LOCAL_EXPORT_LDLIBS := -L$(LOCAL_PATH)/lib/arm64-v8a -ltango_client_api
+endif
+
+ifeq ($(TARGET_ARCH), arm)
+  LOCAL_EXPORT_LDLIBS := -L$(LOCAL_PATH)/lib/armeabi-v7a -ltango_client_api
 endif
 
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include

--- a/tango_support_api/Android.mk
+++ b/tango_support_api/Android.mk
@@ -18,11 +18,19 @@ PROJECT_ROOT:= $(LOCAL_PATH)/..
 include $(CLEAR_VARS)
 LOCAL_MODULE := tango_support_api
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
-ifeq ($(TARGET_ARCH),x86)
-    LOCAL_SRC_FILES := $(LOCAL_PATH)/lib/x86/libtango_support_api.so
-else
-    LOCAL_SRC_FILES := $(LOCAL_PATH)/lib/armeabi-v7a/libtango_support_api.so
+
+ifeq ($(TARGET_ARCH), x86)
+	LOCAL_SRC_FILES := $(LOCAL_PATH)/lib/x86/libtango_support_api.so
 endif
+
+ifeq ($(TARGET_ARCH), arm64)
+	LOCAL_SRC_FILES := $(LOCAL_PATH)/lib/arm64-v8a/libtango_support_api.so
+endif
+
+ifeq ($(TARGET_ARCH), arm)
+	LOCAL_SRC_FILES := $(LOCAL_PATH)/lib/armeabi-v7a/libtango_support_api.so
+endif
+
 include $(PREBUILT_SHARED_LIBRARY)
 
 $(call import-add-path,$(PROJECT_ROOT))


### PR DESCRIPTION
Currently, example projects will only build for armeabi-v7a. This change makes it so that all projects will build for x86, arm64, and arm by default. I've tested this locally and all projects built without issue.