### PR TITLE
New overload method tango_gl

### DIFF
--- a/tango_gl/drawable_object.cc
+++ b/tango_gl/drawable_object.cc
@@ -63,4 +63,12 @@ void DrawableObject::SetVertices(const std::vector<GLfloat>& vertices,
   vertices_ = vertices;
   normals_ = normals;
 }
+
+void DrawableObject::SetVertices(const std::vector<GLfloat>& vertices,
+                                 const std::vector<GLfloat>& normals,
+                                 const std::vector<GLushort>& indices) {
+  vertices_ = vertices;
+  normals_ = normals;
+  indices_ = indices;
+}
 }  // namespace tango_gl

--- a/tango_gl/include/tango-gl/drawable_object.h
+++ b/tango_gl/include/tango-gl/drawable_object.h
@@ -40,6 +40,9 @@ class DrawableObject : public Transform {
                    const std::vector<GLushort>& indices);
   void SetVertices(const std::vector<GLfloat>& vertices,
                    const std::vector<GLfloat>& normals);
+  void SetVertices(const std::vector<GLfloat>& vertices,
+                   const std::vector<GLfloat>& normals,
+                   const std::vector<GLushort>& indices);
   virtual void Render(const glm::mat4& projection_mat,
                       const glm::mat4& view_mat) const = 0;
 


### PR DESCRIPTION
Simply added a single function overload to allow to set normals AND indices at the same time when setting drawing objects info. Simple fix otherwise making a redundant call to set the vertices twice.