### PR TITLE
Fixed TangoInitializationHelper.java for API 24+

### DIFF
--- a/cpp_example_util/app/src/main/java/com/projecttango/examples/cpp/util/TangoInitializationHelper.java
+++ b/cpp_example_util/app/src/main/java/com/projecttango/examples/cpp/util/TangoInitializationHelper.java
@@ -35,8 +35,6 @@ public class TangoInitializationHelper {
   public static final int ARCH_DEFAULT = 0;
   public static final int ARCH_ARM64 = 1;
   public static final int ARCH_ARM32 = 2;
-  public static final int ARCH_X86_64 = 3;
-  public static final int ARCH_X86 = 4;
 
   /**
    * Only for apps using the C API:
@@ -81,35 +79,19 @@ public class TangoInitializationHelper {
     if (!(new File(basePath).exists())) {
       basePath = "/data/data/com.projecttango.tango/libfiles/";
     }
-    Log.i("TangoInitializationHelper", "basePath: " + basePath);
+    Log.i("TangoInitializationHelp", "basePath: " + basePath);
 
     try {
       System.load(basePath + "arm64-v8a/libtango_client_api.so");
       loadedSoId = ARCH_ARM64;
-      Log.i("TangoInitializationHelper", "Success! Using arm64-v8a/libtango_client_api.");
+      Log.i("TangoInitializationHelp", "Success! Using arm64-v8a/libtango_client_api.");
     } catch (UnsatisfiedLinkError e) {
     }
     if (loadedSoId < ARCH_DEFAULT) {
       try {
         System.load(basePath + "armeabi-v7a/libtango_client_api.so");
         loadedSoId = ARCH_ARM32;
-        Log.i("TangoInitializationHelper", "Success! Using armeabi-v7a/libtango_client_api.");
-      } catch (UnsatisfiedLinkError e) {
-      }
-    }
-    if (loadedSoId < ARCH_DEFAULT) {
-      try {
-        System.load(basePath + "x86_64/libtango_client_api.so");
-        loadedSoId = ARCH_X86_64;
-        Log.i("TangoInitializationHelper", "Success! Using x86_64/libtango_client_api.");
-      } catch (UnsatisfiedLinkError e) {
-      }
-    }
-    if (loadedSoId < ARCH_DEFAULT) {
-      try {
-        System.load(basePath + "x86/libtango_client_api.so");
-        loadedSoId = ARCH_X86;
-        Log.i("TangoInitializationHelper", "Success! Using x86/libtango_client_api.");
+        Log.i("TangoInitializationHelp", "Success! Using armeabi-v7a/libtango_client_api.");
       } catch (UnsatisfiedLinkError e) {
       }
     }
@@ -117,7 +99,7 @@ public class TangoInitializationHelper {
       try {
         System.load(basePath + "default/libtango_client_api.so");
         loadedSoId = ARCH_DEFAULT;
-        Log.i("TangoInitializationHelper", "Success! Using default/libtango_client_api.");
+        Log.i("TangoInitializationHelp", "Success! Using default/libtango_client_api.");
       } catch (UnsatisfiedLinkError e) {
       }
     }
@@ -125,7 +107,7 @@ public class TangoInitializationHelper {
       try {
         System.loadLibrary("tango_client_api");
         loadedSoId = ARCH_FALLBACK;
-        Log.i("TangoInitializationHelper", "Falling back to libtango_client_api.so symlink.");
+        Log.i("TangoInitializationHelp", "Falling back to libtango_client_api.so symlink.");
       } catch (UnsatisfiedLinkError e) {
       }
     }


### PR DESCRIPTION
Fixed the new [Log tag 23 character limit](https://developer.android.com/reference/android/util/Log.html#isLoggable%28java.lang.String,%20int%29)  imposed if using API 24+ since `TangoInitializationHelper` is 25 characters

 and also removed x86 options since they were removed in #102 from the `Application.mk` files
